### PR TITLE
set variables to allow large keys

### DIFF
--- a/libresonic-main/src/main/java/org/libresonic/player/dao/schema/mysql/Schema61.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/dao/schema/mysql/Schema61.java
@@ -59,6 +59,9 @@ public class Schema61 extends Schema {
     };
 
     public void execute(JdbcTemplate template) {
+        template.execute("SET GLOBAL innodb_file_format = BARRACUDA");
+        template.execute("SET GLOBAL innodb_large_prefix = ON");
+        
         if (!tableExists(template, "version")) {
 
             LOG.info("Database table 'version' not found.  Creating it.");


### PR DESCRIPTION
Several tables use path VARCHAR(500) as a key. InnoDB doesn't allow such large keys by default.